### PR TITLE
Feature : 채팅 구현 #24

### DIFF
--- a/src/main/java/com/example/challengewithmebe/chat/controller/ChatController.java
+++ b/src/main/java/com/example/challengewithmebe/chat/controller/ChatController.java
@@ -1,0 +1,32 @@
+package com.example.challengewithmebe.chat.controller;
+
+
+import com.example.challengewithmebe.chat.dto.MessageDTO;
+import com.example.challengewithmebe.chat.dto.response.gpt.GPTResponse;
+import com.example.challengewithmebe.chat.service.ChatService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ChatController {
+    private final ChatService chatService;
+
+    @PostMapping( "/chat")
+    public ResponseEntity<GPTResponse> chatGPT(@RequestBody MessageDTO request) throws JsonProcessingException {
+        MessageDTO fullrequest = MessageDTO.builder()
+                .role(request.getRole())
+                .content(request.getContent())
+                .build();
+
+        GPTResponse response = chatService.makePrompt(fullrequest);
+
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/MessageDTO.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/MessageDTO.java
@@ -1,0 +1,15 @@
+package com.example.challengewithmebe.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MessageDTO {
+    private String role;
+    private String content;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/request/PromptDTO.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/request/PromptDTO.java
@@ -1,0 +1,20 @@
+package com.example.challengewithmebe.chat.dto.request;
+
+
+import com.example.challengewithmebe.chat.dto.MessageDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromptDTO {
+    private String model;
+    private double temperature;
+    private List<MessageDTO> messages;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/request/PromptDTO.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/request/PromptDTO.java
@@ -12,9 +12,31 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class PromptDTO {
     private String model;
     private double temperature;
     private List<MessageDTO> messages;
+    private int max_tokens;
+
+    private ResponseFormat response_format;
+    @Getter
+    static class ResponseFormat {
+        private String type;
+
+        public ResponseFormat() {
+            this.type = "json_object";
+        }
+    }
+
+    @Builder
+    public PromptDTO(String model, double temperature, List<MessageDTO> messages) {
+        this.model = model;
+        this.temperature = temperature;
+        this.messages = messages;
+        this.max_tokens = 500;
+        this.response_format = new ResponseFormat();
+    }
 }
+
+
+

--- a/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/Choice.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/Choice.java
@@ -1,0 +1,17 @@
+package com.example.challengewithmebe.chat.dto.response.gpt;
+
+import com.example.challengewithmebe.chat.dto.MessageDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Choice {
+    private String finish_reason;
+    private int index;
+    private MessageDTO message;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/GPTResponse.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/GPTResponse.java
@@ -1,0 +1,19 @@
+package com.example.challengewithmebe.chat.dto.response.gpt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GPTResponse {
+    private int created;
+    private String model;
+    private List<Choice> choices;
+    private Usage usage;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/Usage.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/response/gpt/Usage.java
@@ -1,0 +1,16 @@
+package com.example.challengewithmebe.chat.dto.response.gpt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Usage {
+    private int prompt_token;
+    private int completion_tokens;
+    private int total_tokens;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
+++ b/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
@@ -38,8 +38,12 @@ public class ChatService {
     public List<MessageDTO> makeMessages(MessageDTO messageDTO){
         MessageDTO systemMessage = MessageDTO.builder()
                 .role("system")
-                .content("You're a senior developer helping a questioner solve a coding test.")
-                //todo : 상세 내용 추가 필요.
+                .content("Acting as a senior developer advising students tackling coding tests.\n" +
+                        "Put the response in JSON format with a string value " +
+                        "having 'description' as the key. " +
+                        "If the response includes code, " +
+                        "place it under the key named 'code'." +
+                        "Except for the code, all responses should be in Korean.")
                 .build();
 
         List<MessageDTO> messages = new ArrayList<>();
@@ -55,7 +59,6 @@ public class ChatService {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         List<MessageDTO> messages = makeMessages(messageDTO);
-
 
         PromptDTO requestBody = PromptDTO.builder()
                 .temperature(0.4)

--- a/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
+++ b/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
@@ -1,0 +1,81 @@
+package com.example.challengewithmebe.chat.service;
+
+
+import com.example.challengewithmebe.chat.dto.MessageDTO;
+import com.example.challengewithmebe.chat.dto.request.PromptDTO;
+import com.example.challengewithmebe.chat.dto.response.gpt.GPTResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    @Value("${openai.secretKey}")
+    private String secretKey;
+
+    @Value("${openai.model}")
+    private String model;
+
+    public HttpHeaders gptHeaders(){
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer "+ secretKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    public List<MessageDTO> makeMessages(MessageDTO messageDTO){
+        MessageDTO systemMessage = MessageDTO.builder()
+                .role("system")
+                .content("You're a senior developer helping a questioner solve a coding test.")
+                //todo : 상세 내용 추가 필요.
+                .build();
+
+        List<MessageDTO> messages = new ArrayList<>();
+        messages.add(systemMessage);
+        messages.add(messageDTO);
+        return messages;
+    }
+
+    public GPTResponse makePrompt(MessageDTO messageDTO) throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = gptHeaders();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        List<MessageDTO> messages = makeMessages(messageDTO);
+
+
+        PromptDTO requestBody = PromptDTO.builder()
+                .temperature(0.4)
+                .model(model)
+                .messages(messages)
+                .build();
+
+        HttpEntity<?> requestEntity = new HttpEntity<>(requestBody, headers);
+        String url = "https://api.openai.com/v1/chat/completions";
+
+        ResponseEntity<Object> responseEntity = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                requestEntity,
+                Object.class
+        );
+
+        String jsonEntity = objectMapper.writeValueAsString(responseEntity.getBody()); //에러 추가
+        GPTResponse response = objectMapper.readValue(jsonEntity, GPTResponse.class);
+        return response;
+    }
+
+}

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -14,4 +14,6 @@ spring:
     redis:
       host: localhost
       port: 6379
-
+openai:
+  secretKey: ${OPENAI_SECRET}
+  model: gpt-3.5-turbo-0125


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- <TYPE><IS_BREAK_CHANGE>: Short Description <IssueNumber> -->

<!-- BODY -->

## **타입**

- [x] Feat
- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **변경 내용**

gpt 채팅 기능을 구현했습니다.
기능만 구현했고, 추후 DB에 저장하고 response를 커스텀해야 합니다.
openAI api 사용을 위한 secret key를 yml에 추가하였습니다.

## **체크리스트**

- [x] gpt 채팅

## **관련 이슈**

Resolves: #24 
See also: #24 
