### PR TITLE
Feature/채팅 request response 변경 및 기록 조회 구현/37

### DIFF
--- a/src/main/java/com/example/challengewithmebe/chat/controller/ChatController.java
+++ b/src/main/java/com/example/challengewithmebe/chat/controller/ChatController.java
@@ -1,31 +1,53 @@
 package com.example.challengewithmebe.chat.controller;
 
 
+import com.example.challengewithmebe.chat.domain.Chat;
 import com.example.challengewithmebe.chat.dto.MessageDTO;
+import com.example.challengewithmebe.chat.dto.request.ChatRequest;
+import com.example.challengewithmebe.chat.dto.response.ChatResponse;
+import com.example.challengewithmebe.chat.dto.response.RoomId;
 import com.example.challengewithmebe.chat.dto.response.gpt.GPTResponse;
 import com.example.challengewithmebe.chat.service.ChatService;
+import com.example.challengewithmebe.global.security.jwt.JwtProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class ChatController {
     private final ChatService chatService;
+    private final JwtProvider jwtProvider;
 
-    @PostMapping( "/chat")
-    public ResponseEntity<GPTResponse> chatGPT(@RequestBody MessageDTO request) throws JsonProcessingException {
-        MessageDTO fullrequest = MessageDTO.builder()
-                .role(request.getRole())
-                .content(request.getContent())
-                .build();
+    @PostMapping( "/chat/{roomId}")
+    public ResponseEntity<ChatRequest> chatGPT(
+            @PathVariable Long roomId,
+            @RequestBody ChatRequest request,
+            HttpServletRequest httpServletRequest) throws JsonProcessingException {
+        jwtProvider.extractId(httpServletRequest);
 
-        GPTResponse response = chatService.makePrompt(fullrequest);
+        ChatRequest response = chatService.makeChat(request, roomId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/chat")
+    public ResponseEntity<RoomId> makeChatRoom(HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        RoomId response = chatService.makeChatRoom(memberId);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/chat/{roomId}")
+    public ResponseEntity<ChatResponse> getChat(
+            @PathVariable Long roomId,
+            HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        ChatResponse response = chatService.getChat(memberId,roomId);
 
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/example/challengewithmebe/chat/domain/Chat.java
+++ b/src/main/java/com/example/challengewithmebe/chat/domain/Chat.java
@@ -1,0 +1,29 @@
+package com.example.challengewithmebe.chat.domain;
+
+import com.example.challengewithmebe.global.app.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class Chat extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Column(nullable = false)
+    private String sender;
+
+    @Column(nullable = false)
+    private String message;
+
+}

--- a/src/main/java/com/example/challengewithmebe/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/challengewithmebe/chat/domain/ChatRoom.java
@@ -1,0 +1,28 @@
+package com.example.challengewithmebe.chat.domain;
+
+import com.example.challengewithmebe.global.app.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class ChatRoom extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OrderBy("createdAt DESC")
+    private List<Chat> messages = new ArrayList<>();
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/request/ChatRequest.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/request/ChatRequest.java
@@ -1,0 +1,19 @@
+package com.example.challengewithmebe.chat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRequest {
+    private Long chatRoomId;
+    private String sender;
+    private String message;
+    private LocalDateTime sendTime;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/response/ChatResponse.java
@@ -1,0 +1,21 @@
+package com.example.challengewithmebe.chat.dto.response;
+
+import com.example.challengewithmebe.chat.domain.Chat;
+import com.example.challengewithmebe.chat.dto.request.ChatRequest;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class ChatResponse {
+    private Long roomId;
+    private Long memberId;
+    private List<ChatRequest> messages = new ArrayList<>();
+}

--- a/src/main/java/com/example/challengewithmebe/chat/dto/response/RoomId.java
+++ b/src/main/java/com/example/challengewithmebe/chat/dto/response/RoomId.java
@@ -1,0 +1,12 @@
+package com.example.challengewithmebe.chat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class RoomId {
+    private Long roomId;
+}

--- a/src/main/java/com/example/challengewithmebe/chat/repository/ChatRepository.java
+++ b/src/main/java/com/example/challengewithmebe/chat/repository/ChatRepository.java
@@ -1,0 +1,14 @@
+package com.example.challengewithmebe.chat.repository;
+
+import com.example.challengewithmebe.chat.domain.Chat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+    List<Chat> findAllByChatRoomIdOrderByCreatedAt(Long chatRoomId);
+}

--- a/src/main/java/com/example/challengewithmebe/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/challengewithmebe/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,10 @@
+package com.example.challengewithmebe.chat.repository;
+
+import com.example.challengewithmebe.chat.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom,Long> {
+    void deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
+++ b/src/main/java/com/example/challengewithmebe/chat/service/ChatService.java
@@ -1,15 +1,27 @@
 package com.example.challengewithmebe.chat.service;
 
 
+import com.example.challengewithmebe.chat.domain.Chat;
+import com.example.challengewithmebe.chat.domain.ChatRoom;
 import com.example.challengewithmebe.chat.dto.MessageDTO;
+import com.example.challengewithmebe.chat.dto.request.ChatRequest;
 import com.example.challengewithmebe.chat.dto.request.PromptDTO;
+import com.example.challengewithmebe.chat.dto.response.ChatResponse;
+import com.example.challengewithmebe.chat.dto.response.RoomId;
+import com.example.challengewithmebe.chat.dto.response.gpt.Choice;
 import com.example.challengewithmebe.chat.dto.response.gpt.GPTResponse;
+import com.example.challengewithmebe.chat.repository.ChatRepository;
+import com.example.challengewithmebe.chat.repository.ChatRoomRepository;
+import com.example.challengewithmebe.global.exception.global.BadRequestException;
+import com.example.challengewithmebe.global.exception.notExist.NotExistChatRoomException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +33,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ChatService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRepository chatRepository;
 
     @Value("${openai.secretKey}")
     private String secretKey;
@@ -52,7 +66,7 @@ public class ChatService {
         return messages;
     }
 
-    public GPTResponse makePrompt(MessageDTO messageDTO) throws JsonProcessingException {
+    public Choice makePrompt(MessageDTO messageDTO) throws JsonProcessingException {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = gptHeaders();
         ObjectMapper objectMapper = new ObjectMapper();
@@ -76,8 +90,81 @@ public class ChatService {
                 Object.class
         );
 
-        String jsonEntity = objectMapper.writeValueAsString(responseEntity.getBody()); //에러 추가
-        GPTResponse response = objectMapper.readValue(jsonEntity, GPTResponse.class);
+        String jsonEntity = objectMapper.writeValueAsString(responseEntity.getBody());
+        GPTResponse gptresponse = objectMapper.readValue(jsonEntity, GPTResponse.class);
+        Choice choice = gptresponse.getChoices().get(0);
+
+        return choice;
+    }
+
+    public RoomId makeChatRoom(Long memberId){
+        ChatRoom chatRoom = ChatRoom.builder()
+                .memberId(memberId)
+                .build();
+        ChatRoom newRoom = chatRoomRepository.save(chatRoom);
+
+        return RoomId.builder()
+                .roomId(newRoom.getId())
+                .build();
+    }
+
+    public ChatRequest makeChat(ChatRequest request, Long roomId) throws JsonProcessingException {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(NotExistChatRoomException::new);
+        Chat newChat = Chat.builder()
+                .chatRoom(chatRoom)
+                .message(request.getMessage())
+                .sender(request.getSender())
+                .build();
+
+        Chat savedChat = chatRepository.save(newChat);
+
+        MessageDTO messageDTO = MessageDTO.builder()
+                .role(savedChat.getSender())
+                .content(savedChat.getMessage())
+                .build();
+
+        Choice choice = makePrompt(messageDTO);
+
+        Chat answer = Chat.builder()
+                .sender("gpt")
+                .chatRoom(chatRoom)
+                .message(choice.getMessage().getContent())
+                .build();
+        Chat savedAnswer = chatRepository.save(answer);
+
+        ChatRequest response = ChatRequest.builder()
+                .chatRoomId(savedAnswer.getChatRoom().getId())
+                .message(savedAnswer.getMessage())
+                .sender(savedAnswer.getSender())
+                .sendTime(savedAnswer.getCreatedAt())
+                .build();
+
+        return response;
+    }
+
+    public ChatResponse getChat(Long memberId, Long roomId){
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElseThrow(NotExistChatRoomException::new);
+        if(!chatRoom.getMemberId().equals(memberId)){
+            throw new BadRequestException();
+        }
+
+        List<Chat> chatPage = chatRepository.findAllByChatRoomIdOrderByCreatedAt(roomId);
+
+        List<ChatRequest> chatList = new ArrayList<>();
+
+        for(Chat chat : chatPage){
+            chatList.add(ChatRequest.builder()
+                    .chatRoomId(chat.getChatRoom().getId())
+                    .sender(chat.getSender())
+                    .message(chat.getMessage())
+                    .sendTime(chat.getCreatedAt())
+                    .build());
+        }
+        ChatResponse response = ChatResponse.builder()
+                .memberId(chatRoom.getMemberId())
+                .roomId(chatRoom.getId())
+                .messages(chatList)
+                .build();
         return response;
     }
 


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- <TYPE><IS_BREAK_CHANGE>: Short Description <IssueNumber> -->

<!-- BODY -->

## **타입**

- [x] Feat
- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **변경 내용**

채팅방과 채팅 정보를 db에 저장하고 채팅 response, request를 수정,
채팅 기록 조회 구현.

## **체크리스트**

- [x] 채팅 response, request 서비스에 맞게 수정
- [x] 채팅방 생성
- [x] 채팅 저장
- [x] 채팅 조회

## **관련 이슈**

Resolves: #37 
See also: #37 
