### PR TITLE
Feature/qn a member/46

### DIFF
--- a/src/main/java/com/example/challengewithmebe/global/exception/auth/AuthExceptionAdvice.java
+++ b/src/main/java/com/example/challengewithmebe/global/exception/auth/AuthExceptionAdvice.java
@@ -30,6 +30,13 @@ public class AuthExceptionAdvice {
                 getMessage("notValidToken.message")));
     }
 
+    //5100
+    @ExceptionHandler(OwnerOnlyOperationException.class)
+    protected ResponseEntity<FailResult> OwnerOnlyOperationException(OwnerOnlyOperationException e){
+        return ResponseEntity.status(400).body(responseService.getFailResult(
+                getMessage("ownerOnlyOperation.code"),
+                getMessage("ownerOnlyOperation.message")));
+    }
 
     private String getMessage(String code){
         return getMessage(code,null);

--- a/src/main/java/com/example/challengewithmebe/global/exception/auth/OwnerOnlyOperationException.java
+++ b/src/main/java/com/example/challengewithmebe/global/exception/auth/OwnerOnlyOperationException.java
@@ -1,0 +1,11 @@
+package com.example.challengewithmebe.global.exception.auth;
+
+public class OwnerOnlyOperationException extends RuntimeException{
+    public OwnerOnlyOperationException(String message){
+        super(message);
+    }
+    public OwnerOnlyOperationException(String message, Throwable cause){
+        super(message,cause);
+    }
+    public OwnerOnlyOperationException() {}
+}

--- a/src/main/java/com/example/challengewithmebe/qna/controller/AnswerController.java
+++ b/src/main/java/com/example/challengewithmebe/qna/controller/AnswerController.java
@@ -1,9 +1,9 @@
 package com.example.challengewithmebe.qna.controller;
 
-import com.example.challengewithmebe.qna.domain.Answer;
+import com.example.challengewithmebe.global.security.jwt.JwtProvider;
 import com.example.challengewithmebe.qna.dto.AnswerDTO;
-import com.example.challengewithmebe.qna.dto.QuestionDTO;
 import com.example.challengewithmebe.qna.service.QnAService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +16,7 @@ import java.util.List;
 public class AnswerController {
 
     private final QnAService qnAService;
+    private final JwtProvider jwtProvider;
 
     //특정 질문에 대한 답변 조회
     @GetMapping("/{questionId}")
@@ -25,22 +26,28 @@ public class AnswerController {
 
     // 답변 생성
     @PostMapping(value = {"","/"})
-    public ResponseEntity<Long> postAnswer(@RequestBody AnswerDTO answerDTO){
-        Long savedId = qnAService.addAnswer(answerDTO);
+    public ResponseEntity<Long> postAnswer(
+            @RequestBody AnswerDTO answerDTO,
+            HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Long savedId = qnAService.addAnswer(answerDTO,memberId);
         return ResponseEntity.ok(savedId);
     }
 
     // 답변 삭제
     @DeleteMapping("/{answerId}")
-    public ResponseEntity<Boolean> deleteAnswer(@PathVariable Long answerId) {
-        return ResponseEntity.ok(qnAService.deleteOneAnswer(answerId));
+    public ResponseEntity<Boolean> deleteAnswer(@PathVariable Long answerId, HttpServletRequest request) {
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        return ResponseEntity.ok(qnAService.deleteOneAnswer(answerId,memberId));
     }
 
-    // 질문 업데이트/수정
+    // 답변 업데이트/수정
     @PutMapping(value = {"","/"})
     public ResponseEntity<Long> putAnswer(
-            @RequestBody AnswerDTO answer){
-        Long updatedId = qnAService.updateAnswer(answer);
+            @RequestBody AnswerDTO answer,
+            HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Long updatedId = qnAService.updateAnswer(answer, memberId);
         return ResponseEntity.ok(updatedId);
     }
 }

--- a/src/main/java/com/example/challengewithmebe/qna/controller/QuestionController.java
+++ b/src/main/java/com/example/challengewithmebe/qna/controller/QuestionController.java
@@ -1,9 +1,10 @@
 package com.example.challengewithmebe.qna.controller;
 
-import com.example.challengewithmebe.qna.dto.AnswerDTO;
+import com.example.challengewithmebe.global.security.jwt.JwtProvider;
 import com.example.challengewithmebe.qna.dto.QuestionDTO;
 import com.example.challengewithmebe.qna.dto.QuestionPreviewDTO;
 import com.example.challengewithmebe.qna.service.QnAService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,7 @@ import java.util.List;
 public class QuestionController {
 
     private final QnAService qnAService;
+    private final JwtProvider jwtProvider;
 
     //특정 챌린지 대상이 아닌 모든 질문과 답변 조회
     @GetMapping(value = {"/",""})
@@ -32,25 +34,37 @@ public class QuestionController {
         return ResponseEntity.ok(qnAService.questionForOneProblem(problemId));
     }
 
+    // 특정 질문(1개)과 그에 대한 답변 조회
+    @GetMapping("/{questionId}/detail")
+    public ResponseEntity<QuestionDTO> getOneQuestion(@PathVariable Long questionId) {
+        return ResponseEntity.ok(qnAService.findOneQuestion(questionId));
+    }
+
     // 질문 생성
     @PostMapping(value = {"","/"})
     public ResponseEntity<Long> postQuestion(
-            @RequestBody QuestionDTO question){
-        Long savedId = qnAService.addQuestion(question);
+            @RequestBody QuestionDTO question,
+            HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Long savedId = qnAService.addQuestion(question, memberId);
         return ResponseEntity.ok(savedId);
     }
 
     // 질문 삭제
     @DeleteMapping("/{questionId}")
-    public ResponseEntity<Boolean> deleteQuestion(@PathVariable Long questionId) {
-        return ResponseEntity.ok(qnAService.deleteOneQuestion(questionId));
+    public ResponseEntity<Boolean> deleteQuestion(@PathVariable Long questionId, HttpServletRequest request) {
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Boolean completelyDeleted = qnAService.deleteOneQuestion(questionId, memberId);
+        return ResponseEntity.ok(completelyDeleted);
     }
 
     // 질문 업데이트/수정
     @PutMapping(value = {"","/"})
     public ResponseEntity<Long> putQuestion(
-            @RequestBody QuestionDTO question){
-        Long updatedId = qnAService.updateQuestion(question);
+            @RequestBody QuestionDTO question,
+            HttpServletRequest request){
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Long updatedId = qnAService.updateQuestion(question, memberId);
         return ResponseEntity.ok(updatedId);
     }
 
@@ -58,17 +72,24 @@ public class QuestionController {
     @GetMapping("/group")
     public ResponseEntity<Page<QuestionPreviewDTO>> getAllQuestionPreviews(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size) {
-        Page<QuestionPreviewDTO> questions = qnAService.findAllQuestionPreviews(page, size);
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "all")String type,
+            HttpServletRequest request) {
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Page<QuestionPreviewDTO> questions = qnAService.findAllQuestionPreviews(page, size, type, memberId);
         return ResponseEntity.ok(questions);
     }
 
+    // 특정 문제에 대한 페이지로 보기(미리보기)
     @GetMapping("/{problemId}/group")
     public ResponseEntity<Page<QuestionPreviewDTO>> getQuestionPreviewsForSpecificProblem(
             @PathVariable Long problemId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size) {
-        Page<QuestionPreviewDTO> questions = qnAService.findQuestionPreviewsForSpecificProblem(problemId, page, size);
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "all")String type,
+            HttpServletRequest request) {
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Page<QuestionPreviewDTO> questions = qnAService.findQuestionPreviewsForSpecificProblem(problemId, page, size, type, memberId);
         return ResponseEntity.ok(questions);
     }
 }

--- a/src/main/java/com/example/challengewithmebe/qna/repository/QuestionRepository.java
+++ b/src/main/java/com/example/challengewithmebe/qna/repository/QuestionRepository.java
@@ -13,4 +13,10 @@ public interface QuestionRepository extends JpaRepository<Question,Long> {
     // 특정 문제에 대한 질문들 페이지로 넘김
     Page<Question> findByProblemId(Long problemId, Pageable pageable);
 
+    // 특정 문제에 대한 질문 중 특정 사용자가 작성한 질문들만 페이지로 넘김
+    Page<Question> findByProblemIdAndMemberId_Id(Long problemId,Long memberId, Pageable pageable);
+
+    // 모든 질문 중 특정 사용자가 작성한 질문들만 페이지로 넘김
+    Page<Question> findByMemberId_Id(Long MemberId,Pageable pageable);
+
 }

--- a/src/main/java/com/example/challengewithmebe/solution/controller/SolutionController.java
+++ b/src/main/java/com/example/challengewithmebe/solution/controller/SolutionController.java
@@ -1,7 +1,9 @@
 package com.example.challengewithmebe.solution.controller;
 
+import com.example.challengewithmebe.global.security.jwt.JwtProvider;
 import com.example.challengewithmebe.solution.dto.SolutionDTO;
 import com.example.challengewithmebe.solution.service.SolutionService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,7 @@ import java.util.Map;
 public class SolutionController {
 
     private final SolutionService solutionService;
+    private final JwtProvider jwtProvider;
 
     @GetMapping(value = {"", "/"})
     public ResponseEntity<List<SolutionDTO>> getAllSolutions(){
@@ -43,8 +46,10 @@ public class SolutionController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int size,
             @RequestParam(defaultValue = "java") String language,
-            @RequestParam(defaultValue = "all") String type) {
-        Page<SolutionDTO> solutions = solutionService.findSolutionPages(page, size, language, type, problemId);
+            @RequestParam(defaultValue = "all") String type,
+            HttpServletRequest request) {
+        Long memberId = Long.valueOf(jwtProvider.extractId(request));
+        Page<SolutionDTO> solutions = solutionService.findSolutionPages(page, size, language, type, problemId, memberId);
         return ResponseEntity.ok(solutions);
     }
 

--- a/src/main/java/com/example/challengewithmebe/solution/service/SolutionService.java
+++ b/src/main/java/com/example/challengewithmebe/solution/service/SolutionService.java
@@ -38,11 +38,10 @@ public class SolutionService {
     }
 
     // 특정 문제에 대한 풀이 페이지 조회
-    public Page<SolutionDTO> findSolutionPages(int page, int size, String language, String type, Long problemId) {
+    public Page<SolutionDTO> findSolutionPages(int page, int size, String language, String type, Long problemId,Long memberId) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("modifiedAt").descending());
         Page<Object[]> solutions;
         if(type.equals("my")){
-            Long memberId = 0L;
             solutions = solutionRepository.
                     findByIsCorrectTrueAndLanguageAndMemberIdAndProblemId(language, memberId, problemId, pageable);
         } else {
@@ -51,11 +50,6 @@ public class SolutionService {
         }
         return convertToSolutionDTOPage(solutions, pageable);
     }
-
-
-
-
-
 
     private List<SolutionDTO> convertToSolutionDTOList(List<Object[]> submits){
         List<SolutionDTO> solutionDTOs = new ArrayList<>();

--- a/src/main/resources/i18n/exception_ko.yml
+++ b/src/main/resources/i18n/exception_ko.yml
@@ -49,3 +49,7 @@ notExistChatRoom:
 aiBehaviorError:
   code: "9200"
   message: "AI가 정상 작동하지 않아요."
+
+ownerOnlyOperation:
+  code: "5100"
+  message: "작성자만 수정, 삭제가 가능해요."


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- <TYPE><IS_BREAK_CHANGE>: Short Description <IssueNumber> -->

<!-- BODY -->

## **타입**

- [x] Feat
- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **변경 내용**

QnA와 풀이 파트에서 로그인 후 사용 가능한 부분을 처리하는 과정을 추가했습니다.

## **체크리스트**

- [x] 작성한 사용자만 QnA를 수정, 삭제할 수 있도록 변경
- [x] 작성한 사용자가 아닌 사용자가 QnA 수정, 삭제하려고 시도할 경우 에러 처리
- [x] QnA 작성시 따로 memberId를 body에 추가하지 않아도 토큰을 활용한 로그인 정보로 자동으로 작성자 처리
- [x] 한 개의 질문과 그에 대한 답변들 보는 기능 추가

## **관련 이슈**

Resolves: #46
See also:
